### PR TITLE
Default data type of the deleted_at field was fixed

### DIFF
--- a/src/Commands/Make.js
+++ b/src/Commands/Make.js
@@ -51,7 +51,7 @@ Make._up = function (table, createTable) {
     return `this.create('${table}', function (table) {
       table.increments('id')
       table.timestamps()
-      table.timestamp('deleted_at')
+      table.dateTime('deleted_at')
     })`
   }
   return `this.table('${table}', function (table) {


### PR DESCRIPTION
The type of the `deleted_at` field must be `dateTime`, not `timestamps`.

https://github.com/adonisjs/adonis-lucid/issues/18