### PR TITLE
Fix bug in PostgreSQL with get migrated list

### DIFF
--- a/src/Migrations/Mixins/Migrate.js
+++ b/src/Migrations/Mixins/Migrate.js
@@ -244,7 +244,7 @@ Migrate._mapMigrationsToActions = function (migrationsList, direction) {
  * @private
  */
 Migrate._getMigratedFiles = function () {
-  return this.database.select('name').from(this.migrationsTable).pluck('name')
+  return this.database.select('name').from(this.migrationsTable).orderBy('name').pluck('name')
 }
 
 /**
@@ -261,6 +261,7 @@ Migrate._getFilesTillBatch = function (batch) {
     .select('name')
     .from(this.migrationsTable)
     .where('batch', '>', batch)
+    .orderBy('name')
     .pluck('name')
 }
 


### PR DESCRIPTION
Fix #77. This problem specific for PostgreSQL DB.

The rows are stored in the order in which they were saved to disk. This order may not coincide with the ID. For example, it is expected to 
SELECT name FROM table
1. name1
2. name2
3. name3

But the conclusion may be different
1. name1
3. name3
2. name2