### PR TITLE
feat(lucid) add merge method to model instance

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -212,6 +212,20 @@ class BaseModel {
    */
   fill (attributes) {
     this.$attributes = {}
+    this.merge(attributes)
+  }
+
+  /**
+   * Merge attributes into on a model instance without
+   * overriding existing attributes and their values
+   *
+   * @method fill
+   *
+   * @param  {Object} attributes
+   *
+   * @return {void}
+   */
+  merge (attributes) {
     _.each(attributes, (value, key) => this.set(key, value))
   }
 

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -136,6 +136,30 @@ test.group('Model', (group) => {
     assert.deepEqual(user.$attributes, { username: 'VIRK', age: 22 })
   })
 
+  test('do not remove attribute values when calling merge', (assert) => {
+    class User extends Model {
+    }
+
+    User._bootIfNotBooted()
+    const user = new User()
+    user.fill({ username: 'virk', age: 22 })
+    user.merge({ age: 23 })
+    assert.deepEqual(user.$attributes, { username: 'virk', age: 23 })
+  })
+
+  test('call setters when defining attributes via merge', (assert) => {
+    class User extends Model {
+      setUsername (username) {
+        return username.toUpperCase()
+      }
+    }
+
+    User._bootIfNotBooted()
+    const user = new User()
+    user.merge({ username: 'virk', age: 22 })
+    assert.deepEqual(user.$attributes, { username: 'VIRK', age: 22 })
+  })
+
   test('call setters when defining attributes manually', (assert) => {
     class User extends Model {
       setUsername (username) {


### PR DESCRIPTION
Adds the method `merge(<attributes>)` to model instances.

This allows for models to be mass updated without having to manually define attribute values or using the `fill()` method which overrides existing attributes.

Docs PR coming soon