### PR TITLE
Clean up tmp dirs before linting and running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ npm-debug.log
 .idea
 out
 .nyc_output
-test/tmp
+test/**/tmp
+test/functional/database

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "standard",
-    "pretest": "npm run lint",
+    "pretest": "npm run test:cleanup && npm run lint",
+    "test:cleanup": "rm -rf test/functional/database && rm -rf test/unit/tmp",
     "posttest": "npm run coverage",
     "test:local": "FORCE_COLOR=true DB=sqlite node bin/index.js --local",
     "test": "nyc npm run test:local",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "lint": "standard",
-    "pretest": "npm run test:cleanup && npm run lint",
+    "pretest": "npm run lint",
     "test:cleanup": "rm -rf test/functional/database && rm -rf test/unit/tmp",
     "posttest": "npm run coverage",
-    "test:local": "FORCE_COLOR=true DB=sqlite node bin/index.js --local",
+    "test:local": "npm run test:cleanup && FORCE_COLOR=true DB=sqlite node bin/index.js --local",
     "test": "nyc npm run test:local",
     "test:win": "set FORCE_COLOR=true && node bin/index.js --win",
     "coverage": "nyc report --reporter=text-lcov | coveralls"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "standard",
     "pretest": "npm run lint",
     "test:cleanup": "rm -rf test/functional/database && rm -rf test/unit/tmp",
-    "posttest": "npm run coverage",
+    "posttest": "npm run test:cleanup && npm run coverage",
     "test:local": "npm run test:cleanup && FORCE_COLOR=true DB=sqlite node bin/index.js --local",
     "test": "nyc npm run test:local",
     "test:win": "set FORCE_COLOR=true && node bin/index.js --win",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "standard",
-    "pretest": "npm run lint",
+    "pretest": "npm run test:cleanup && npm run lint",
     "test:cleanup": "rm -rf test/functional/database && rm -rf test/unit/tmp",
     "posttest": "npm run test:cleanup && npm run coverage",
     "test:local": "npm run test:cleanup && FORCE_COLOR=true DB=sqlite node bin/index.js --local",


### PR DESCRIPTION
Small patch. If I `^c` while tests are running, it sometimes doesn't clean up temp files, then `standard` reads them on the next run and fails :)