### PR TITLE
Initialize traits so spec runs independently

### DIFF
--- a/test/unit/traits.spec.js
+++ b/test/unit/traits.spec.js
@@ -53,7 +53,7 @@ test.group('Traits', (group) => {
       }
     }
   }).timeout(0)
-  
+
   group.beforeEach(() => {
     ioc.restore()
   })

--- a/test/unit/traits.spec.js
+++ b/test/unit/traits.spec.js
@@ -9,13 +9,51 @@
  * file that was distributed with this source code.
 */
 
+require('../../lib/iocResolver').setFold(require('@adonisjs/fold'))
 const test = require('japa')
+const fs = require('fs-extra')
+const path = require('path')
 const { ioc } = require('@adonisjs/fold')
+const { Config, setupResolver } = require('@adonisjs/sink')
 const helpers = require('./helpers')
 const Model = require('../../src/Lucid/Model')
+const DatabaseManager = require('../../src/Database/Manager')
 const QueryBuilder = require('../../src/Lucid/QueryBuilder')
 
 test.group('Traits', (group) => {
+  group.before(async () => {
+    ioc.singleton('Adonis/Src/Database', function () {
+      const config = new Config()
+      config.set('database', {
+        connection: 'testing',
+        testing: helpers.getConfig()
+      })
+      return new DatabaseManager(config)
+    })
+    ioc.alias('Adonis/Src/Database', 'Database')
+
+    await fs.ensureDir(path.join(__dirname, './tmp'))
+    await helpers.createTables(ioc.use('Database'))
+    setupResolver()
+  })
+
+  group.afterEach(async () => {
+    await ioc.use('Database').table('users').truncate()
+    await ioc.use('Database').table('my_users').truncate()
+  })
+
+  group.after(async () => {
+    await helpers.dropTables(ioc.use('Database'))
+    ioc.use('Database').close()
+    try {
+      await fs.remove(path.join(__dirname, './tmp'))
+    } catch (error) {
+      if (process.platform !== 'win32' || error.code !== 'EBUSY') {
+        throw error
+      }
+    }
+  }).timeout(0)
+  
   group.beforeEach(() => {
     ioc.restore()
   })


### PR DESCRIPTION
I'm not sure if anyone else needs this, but in testing I like to run spec files independently while developing. The `traits.spec.js` wouldn't run independently, I guess it needed other tests to create the DB for it. So I stole the setup from `lucid.spec.js` and now `traits.spec.js` runs both by itself and with other tests.