### PR TITLE
toJSON fix

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -187,7 +187,9 @@ class BaseModel {
       '$relations',
       '$sideLoaded',
       '$parent',
-      '$frozen'
+      '$frozen',
+      '$visible',
+      '$hidden'
     ]
 
     this.$attributes = {}
@@ -197,6 +199,8 @@ class BaseModel {
     this.$sideLoaded = {}
     this.$parent = null
     this.$frozen = false
+    this.$visible = this.constructor.visible
+    this.$hidden = this.constructor.hidden
   }
 
   /**

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -471,26 +471,6 @@ class Model extends BaseModel {
   }
 
   /**
-   * Instantiate the model by defining constructor properties
-   * and also setting `__setters__` to tell the proxy that
-   * these values should be set directly on the constructor
-   * and not on the `attributes` object.
-   *
-   * @method instantiate
-   *
-   * @return {void}
-   *
-   * @private
-   */
-  _instantiate () {
-    super._instantiate()
-    this.__setters__.push('$visible')
-    this.__setters__.push('$hidden')
-    this.$visible = this.constructor.visible
-    this.$hidden = this.constructor.hidden
-  }
-
-  /**
    * Formats the date fields from the payload, only
    * when they are marked as dates and there are
    * no setters defined for them.

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -408,6 +408,8 @@ class Model extends BaseModel {
   static async create (payload, trx) {
     const modelInstance = new this()
     modelInstance.fill(payload)
+    modelInstance.$visible = this.visible
+    modelInstance.$hidden = this.hidden
     await modelInstance.save(trx)
     return modelInstance
   }
@@ -1326,13 +1328,13 @@ class Model extends BaseModel {
     }
 
     if (!this.isNew) {
-      const attributes = await this.constructor.find(this.primaryKeyValue)
-      if (!attributes) {
+      const newInstance = await this.constructor.find(this.primaryKeyValue)
+      if (!newInstance) {
         throw GE
           .RuntimeException
           .invoke(`Cannot reload model since row with ${this.constructor.primaryKey} ${this.primaryKeyValue} has been removed`)
       }
-      this.newUp(attributes)
+      this.newUp(newInstance.$attributes)
     }
   }
 }

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -408,8 +408,6 @@ class Model extends BaseModel {
   static async create (payload, trx) {
     const modelInstance = new this()
     modelInstance.fill(payload)
-    modelInstance.$visible = this.visible
-    modelInstance.$hidden = this.hidden
     await modelInstance.save(trx)
     return modelInstance
   }
@@ -485,28 +483,11 @@ class Model extends BaseModel {
    * @private
    */
   _instantiate () {
-    this.__setters__ = [
-      '$attributes',
-      '$persisted',
-      'primaryKeyValue',
-      '$originalAttributes',
-      '$relations',
-      '$sideLoaded',
-      '$parent',
-      '$frozen',
-      '$visible',
-      '$hidden'
-    ]
-
-    this.$attributes = {}
-    this.$persisted = false
-    this.$originalAttributes = {}
-    this.$relations = {}
-    this.$sideLoaded = {}
-    this.$parent = null
-    this.$frozen = false
-    this.$visible = null
-    this.$hidden = null
+    super._instantiate()
+    this.__setters__.push('$visible')
+    this.__setters__.push('$hidden')
+    this.$visible = this.constructor.visible
+    this.$hidden = this.constructor.hidden
   }
 
   /**

--- a/test/unit/lucid-serializer.spec.js
+++ b/test/unit/lucid-serializer.spec.js
@@ -224,6 +224,17 @@ test.group('Relations | Serializer', (group) => {
     assert.equal(json.lastPage, 1)
   })
 
+  test('test toJSON with default visible() and hidden()', async (assert) => {
+    class User extends Model {
+    }
+    User._bootIfNotBooted()
+    await ioc.use('Database').table('users').insert([{ username: 'virk' }, { username: 'nikk' }])
+
+    // Test 1 - find in DB
+    const a = await User.find(1)
+    assert.include(a.toJSON(), {id: 1, username: 'virk'})
+  })
+
   test('test toJSON with visible()', async (assert) => {
     class User extends Model {
       static get visible () {
@@ -235,20 +246,20 @@ test.group('Relations | Serializer', (group) => {
 
     // Test 1 - find in DB
     const a = await User.find(1)
-    assert.deepEqual(a.toJSON(), {id: 1, username: 'virk'})
+    assert.deepEqual(a.toJSON(), {id: 1, username: 'virk'}, 'Test 1 failed')
 
     // // test 2 - find in db then reload
     const b = await User.find(1)
     await b.reload()
-    assert.deepEqual(b.toJSON(), {id: 1, username: 'virk'})
+    assert.deepEqual(b.toJSON(), {id: 1, username: 'virk'}, 'Test 2 failed')
 
     // // test 3 - create
     const c = await User.create({username: 'ben'})
-    assert.deepEqual(c.toJSON(), {id: 3, username: 'ben'})
+    assert.deepEqual(c.toJSON(), {id: 3, username: 'ben'}, 'Test 3 failed')
 
     // // test 4 - create then reload from db
     const d = await User.create({username: 'simon'})
     await d.reload()
-    assert.deepEqual(d.toJSON(), {id: 4, username: 'simon'})
+    assert.deepEqual(d.toJSON(), {id: 4, username: 'simon'}, 'Test 4 failed')
   })
 })

--- a/test/unit/lucid-serializer.spec.js
+++ b/test/unit/lucid-serializer.spec.js
@@ -223,4 +223,32 @@ test.group('Relations | Serializer', (group) => {
     assert.equal(json.perPage, 20)
     assert.equal(json.lastPage, 1)
   })
+
+  test('test toJSON with visible()', async (assert) => {
+    class User extends Model {
+      static get visible () {
+        return ['id', 'username']
+      }
+    }
+    User._bootIfNotBooted()
+    await ioc.use('Database').table('users').insert([{ username: 'virk' }, { username: 'nikk' }])
+
+    // Test 1 - find in DB
+    const a = await User.find(1)
+    assert.deepEqual(a.toJSON(), {id: 1, username: 'virk'})
+
+    // // test 2 - find in db then reload
+    const b = await User.find(1)
+    await b.reload()
+    assert.deepEqual(b.toJSON(), {id: 1, username: 'virk'})
+
+    // // test 3 - create
+    const c = await User.create({username: 'ben'})
+    assert.deepEqual(c.toJSON(), {id: 3, username: 'ben'})
+
+    // // test 4 - create then reload from db
+    const d = await User.create({username: 'simon'})
+    await d.reload()
+    assert.deepEqual(d.toJSON(), {id: 4, username: 'simon'})
+  })
 })


### PR DESCRIPTION
Fix for https://github.com/adonisjs/adonis-lucid/issues/210

This feels kind of hacky. The central problem is that Lucid doesn't know how to instantiate a new model. It's done one way in `QueryBuilder`, another way in `create()`, and a third way in `newUp()`

Suggestions?