### PR TITLE
Update BelongsToMany.js

### DIFF
--- a/src/Lucid/Relations/BelongsToMany.js
+++ b/src/Lucid/Relations/BelongsToMany.js
@@ -422,7 +422,7 @@ class BelongsToMany extends BaseRelation {
    * @chainable
    */
   pivotModel (pivotModel) {
-    this._PivotModel = pivotModel
+    this._PivotModel = use(pivotModel)
     return this
   }
 


### PR DESCRIPTION
I was trying to use pivotModel() instead of pivotTable() and I got this error : 
ER_NO_SUCH_TABLE: Table 'adonis2.undefined' doesn't exist
In this error the table's name is undefined but when I use pivotTable() it works fine!
so the problem is it is setting this._PivotModel to the address of pivot model.
So I used use() method to fix this.