### PR TITLE
feat(lucid): allow to unfreeze model instance

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -245,6 +245,17 @@ class BaseModel {
   }
 
   /**
+   * Unfreezes the model allowing further modifications
+   *
+   * @method unfreeze
+   *
+   * @return {void}
+   */
+  unfreeze () {
+    this.$frozen = false
+  }
+
+  /**
    * Converts model instance toJSON using the serailizer
    * toJSON method
    *

--- a/src/Lucid/Model/proxyHandler.js
+++ b/src/Lucid/Model/proxyHandler.js
@@ -24,7 +24,7 @@ const proxyHandler = exports = module.exports = {}
  * @param  {Mixed} value
  */
 proxyHandler.set = function (target, name, value) {
-  if (target.isDeleted && name !== 'frozen') {
+  if (target.isDeleted && name !== '$frozen') {
     throw CE.ModelException.deletedInstance(target.constructor.name)
   }
 

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -1347,6 +1347,18 @@ test.group('Model', (group) => {
     assert.equal(userQuery.sql, helpers.formatQuery('delete from "users" where "id" = ?'))
   })
 
+  test('allow to unfreeze model instance', async (assert) => {
+    assert.plan(1)
+    class User extends Model {
+    }
+
+    const user = new User()
+    user.freeze()
+    user.unfreeze()
+
+    assert.isFalse(user.$frozen)
+  })
+
   test('dates should be an empty array when createdAtColumn and updatedAtColumn is not defined', async (assert) => {
     class User extends Model {
       static get createdAtColumn () {


### PR DESCRIPTION
I was working on SoftDelete trait for models. I've found that there's a bug in `proxyHandler` which prevented from unfreezing model.

This PR introduces `unfreeze()` method which allows to set `$frozen` to `false`.