### PR TITLE
Allow booting from multiple models

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -47,8 +47,12 @@ class Model extends BaseModel {
    * @static
    */
   static _bootIfNotBooted () {
-    if (!this.$booted) {
-      this.$booted = true
+    if (!this.$bootedBy) {
+      this.$bootedBy = []
+    }
+    
+    if (this.$bootedBy.indexOf(this.name) < 0) {
+      this.$bootedBy.push(this.name)
       this.boot()
     }
   }


### PR DESCRIPTION
By creating a list of models that have booted this object, we can allow all models' boot methods to run, without re-implementing `this.name !== "Generic"` work-arounds in deeply-nested model situations.

Please note: this is a suggestion with code. You don't have to merge it exactly, but think about whether or not this could work, and make people's lives easier...

* https://github.com/adonisjs/adonis-lucid/issues/98
* https://github.com/adonisjs/adonis-lucid/issues/274
  