### PR TITLE
Add a keep-alive option to all migration commands. Fixes #305.

### DIFF
--- a/commands/MigrationRefresh.js
+++ b/commands/MigrationRefresh.js
@@ -61,7 +61,7 @@ class MigrationRefresh extends BaseMigration {
     this._validateState(force)
 
     if (keepAlive) {
-      this.migration.keepAlive();
+      this.migration.keepAlive()
     }
 
     await ace.call('migration:reset', {}, { log, force, silent })

--- a/commands/MigrationRefresh.js
+++ b/commands/MigrationRefresh.js
@@ -26,6 +26,7 @@ class MigrationRefresh extends BaseMigration {
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
     { --log: Log SQL queries instead of executing them }
+    { -a, --keep-alive: Do not close the database connection }
     `
   }
 
@@ -52,11 +53,17 @@ class MigrationRefresh extends BaseMigration {
    * @param  {Boolean} options.log
    * @param  {Boolean} options.force
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, silent }) {
+  async handle (args, { log, force, silent, keepAlive }) {
     this._validateState(force)
+
+    if (keepAlive) {
+      this.migration.keepAlive();
+    }
+
     await ace.call('migration:reset', {}, { log, force, silent })
     await ace.call('migration:run', {}, { log, force, silent })
   }

--- a/commands/MigrationReset.js
+++ b/commands/MigrationReset.js
@@ -27,6 +27,7 @@ class MigrationReset extends BaseMigration {
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
     { --log: Log SQL queries instead of executing them }
+    { -a, --keep-alive: Do not close the database connection }
     `
   }
 
@@ -52,12 +53,17 @@ class MigrationReset extends BaseMigration {
    * @param  {Boolean} options.log
    * @param  {Boolean} options.force
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, silent }) {
+  async handle (args, { log, force, silent, keepAlive }) {
     try {
       this._validateState(force)
+
+      if (keepAlive) {
+        this.migration.keepAlive();
+      }
 
       const startTime = process.hrtime()
       const { migrated, status, queries } = await this.migration.down(this._getSchemaFiles(), 0, log)

--- a/commands/MigrationReset.js
+++ b/commands/MigrationReset.js
@@ -62,7 +62,7 @@ class MigrationReset extends BaseMigration {
       this._validateState(force)
 
       if (keepAlive) {
-        this.migration.keepAlive();
+        this.migration.keepAlive()
       }
 
       const startTime = process.hrtime()

--- a/commands/MigrationRollback.js
+++ b/commands/MigrationRollback.js
@@ -66,7 +66,7 @@ class MirationRollback extends BaseMigration {
       this._validateState(force)
 
       if (keepAlive) {
-        this.migration.keepAlive();
+        this.migration.keepAlive()
       }
 
       const startTime = process.hrtime()

--- a/commands/MigrationRollback.js
+++ b/commands/MigrationRollback.js
@@ -28,6 +28,7 @@ class MirationRollback extends BaseMigration {
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
     { --log: Log SQL queries instead of executing them }
+    { -a, --keep-alive: Do not close the database connection }
     `
   }
 
@@ -54,14 +55,19 @@ class MirationRollback extends BaseMigration {
    * @param  {Boolean} options.force
    * @param  {Number} options.batch
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, batch, silent }) {
+  async handle (args, { log, force, batch, silent, keepAlive }) {
     try {
       batch = batch ? Number(batch) : null
 
       this._validateState(force)
+
+      if (keepAlive) {
+        this.migration.keepAlive();
+      }
 
       const startTime = process.hrtime()
       const { migrated, status, queries } = await this.migration.down(this._getSchemaFiles(), batch, log)

--- a/commands/MigrationRun.js
+++ b/commands/MigrationRun.js
@@ -62,7 +62,7 @@ class MigrationRun extends BaseMigration {
       this._validateState(force)
 
       if (keepAlive) {
-        this.migration.keepAlive();
+        this.migration.keepAlive()
       }
 
       const startTime = process.hrtime()

--- a/commands/MigrationRun.js
+++ b/commands/MigrationRun.js
@@ -27,6 +27,7 @@ class MigrationRun extends BaseMigration {
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
     { --log: Log SQL queries instead of executing them }
+    { -a, --keep-alive: Do not close the database connection }
     `
   }
 
@@ -52,12 +53,17 @@ class MigrationRun extends BaseMigration {
    * @param  {Boolean} options.log
    * @param  {Boolean} options.force
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, silent }) {
+  async handle (args, { log, force, silent, keepAlive }) {
     try {
       this._validateState(force)
+
+      if (keepAlive) {
+        this.migration.keepAlive();
+      }
 
       const startTime = process.hrtime()
       const { migrated, status, queries } = await this.migration.up(this._getSchemaFiles(), log)

--- a/commands/MigrationStatus.js
+++ b/commands/MigrationStatus.js
@@ -20,7 +20,11 @@ class MigrationStatus extends BaseMigration {
    * @return {String}
    */
   static get signature () {
-    return 'migration:status'
+    return `
+    migration:status
+    { -a, --keep-alive: Do not close the database connection }
+    `
+
   }
 
   /**
@@ -40,9 +44,17 @@ class MigrationStatus extends BaseMigration {
    *
    * @method handle
    *
+   * @param  {Object} args
+   * @param  {Boolean} options.keepAlive
+   *
    * @return {void|Array}
    */
-  async handle () {
+  async handle (args, { keepAlive} ) {
+
+    if (keepAlive) {
+      this.migration.keepAlive();
+    }
+
     try {
       const migrations = await this.migration.status(this._getSchemaFiles())
       const head = ['File name', 'Migrated', 'Batch']

--- a/commands/MigrationStatus.js
+++ b/commands/MigrationStatus.js
@@ -24,7 +24,6 @@ class MigrationStatus extends BaseMigration {
     migration:status
     { -a, --keep-alive: Do not close the database connection }
     `
-
   }
 
   /**
@@ -49,10 +48,9 @@ class MigrationStatus extends BaseMigration {
    *
    * @return {void|Array}
    */
-  async handle (args, { keepAlive} ) {
-
+  async handle (args, {keepAlive}) {
     if (keepAlive) {
-      this.migration.keepAlive();
+      this.migration.keepAlive()
     }
 
     try {

--- a/src/Migration/index.js
+++ b/src/Migration/index.js
@@ -30,7 +30,7 @@ class Migration {
     this.db = Database
     this._migrationsTable = Config.get('database.migrationsTable', 'adonis_schema')
     this._lockTable = `${this._migrationsTable}_lock`
-    this.isKeepAliveEnabled = false;
+    this.isKeepAliveEnabled = false
   }
 
   /**
@@ -318,7 +318,7 @@ class Migration {
    * @return {void}
    */
   keepAlive (enabled = true) {
-    this.isKeepAliveEnabled = enabled;
+    this.isKeepAliveEnabled = enabled
   }
 
   /**

--- a/src/Migration/index.js
+++ b/src/Migration/index.js
@@ -30,6 +30,7 @@ class Migration {
     this.db = Database
     this._migrationsTable = Config.get('database.migrationsTable', 'adonis_schema')
     this._lockTable = `${this._migrationsTable}_lock`
+    this.isKeepAliveEnabled = false;
   }
 
   /**
@@ -301,7 +302,23 @@ class Migration {
    */
   async _cleanup () {
     await this._removeLock()
-    this.db.close()
+
+    if (!this.isKeepAliveEnabled) {
+      this.db.close()
+    }
+  }
+
+  /**
+   * Enable or disable keepAlive, which prevents the database connection from being closed.
+   *
+   * @method keepAlive
+   *
+   * @param {boolean}enabled
+   *
+   * @return {void}
+   */
+  keepAlive (enabled = true) {
+    this.isKeepAliveEnabled = enabled;
   }
 
   /**
@@ -456,7 +473,10 @@ class Migration {
       .table(this._migrationsTable)
       .orderBy('name')
 
-    this.db.close()
+    if (!this.isKeepAliveEnabled) {
+      this.db.close()
+    }
+
     return _.map(schemas, (schema, name) => {
       const migration = _.find(migrated, (mig) => mig.name === name)
       return {


### PR DESCRIPTION
This prevents the migration commands from closing the database connection which allows for using an in-memory database during testing. Without this the connection is closed after the migrations are run and the next connection starts with an empty database.