### PR TITLE
fix(lucid): Add promise rejection when beginTransaction fails. #308

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -183,7 +183,9 @@ class Database {
         .knex
         .transaction(function (trx) {
           resolve(trx)
-        }).catch(() => {})
+        }).catch(function (trx) {
+          reject(trx)
+        })
     })
   }
 


### PR DESCRIPTION
Fixes Issue #308:

Properly performs promise rejection when connection errors occur.

For example DNS errors prior to this fix would simply cause beginTransaction to silently timeout, after this fix however you can properly catch the error.

> Error: getaddrinfo ENOTFOUND devv-db devv-db:5432
> at errnoException (dns.js:50:10)
> at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:92:26)