### PR TITLE
Implementing static method `from()` for models

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -294,11 +294,13 @@ class BaseModel {
    *
    * @param  {Object} attributes
    *
-   * @return {void}
+   * @chainable
    */
   fill (attributes) {
     this.$attributes = {}
     this.merge(attributes)
+    
+    return this
   }
 
   /**
@@ -309,10 +311,12 @@ class BaseModel {
    *
    * @param  {Object} attributes
    *
-   * @return {void}
+   * @chainable
    */
   merge (attributes) {
     _.each(attributes, (value, key) => this.set(key, value))
+    
+    return this
   }
 
   /**

--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -320,6 +320,22 @@ class BaseModel {
   }
 
   /**
+   * Instantiates the model and fill it with given attributes
+   * i.e: User.from({ email, password }).save()
+   *
+   * @method from
+   *
+   * @param  {Object} attributes
+   *
+   * @static
+   *
+   * @chainable
+   */
+  static from (attributes) {
+    return (new this()).fill(attributes)
+  }
+
+  /**
    * Freezes the model instance for modifications
    *
    * @method freeze

--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -299,7 +299,7 @@ class BaseModel {
   fill (attributes) {
     this.$attributes = {}
     this.merge(attributes)
-    
+
     return this
   }
 
@@ -315,7 +315,7 @@ class BaseModel {
    */
   merge (attributes) {
     _.each(attributes, (value, key) => this.set(key, value))
-    
+
     return this
   }
 

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -173,6 +173,18 @@ test.group('Model', (group) => {
     assert.deepEqual(user.$attributes, { username: 'VIRK' })
   })
 
+  test('new model instance with given attributes is created using from', (assert) => {
+    class User extends Model {
+      setEmail (email) {
+        return email.toLowerCase()
+      }
+    }
+
+    const user = User.from({ email: 'TEST@test.com' })
+    assert.instanceOf(user, User)
+    assert.deepEqual(user.$attributes, { email: 'test@test.com' })
+  })
+
   test('save attributes to the database and update model state', async (assert) => {
     class User extends Model {
     }


### PR DESCRIPTION
I find myself doing this lots of times when dealing with raw collections of records

```js
    const result = new Model()
    result.fill(rawData)
    return result
```

So just like `Array.from()` works, I thought we can implement a more "functional" approach, like `User.from({ email, password }).save()`

Feel free to ask for any modification or reject this :+1: 