### PR TITLE
fix created_at misbehavior on save

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -15,7 +15,7 @@ const Hooks = require('../Hooks')
 const GlobalScopes = require('../GlobalScope')
 const VanillaSerializer = require('../Serializers/Vanilla')
 const { ioc } = require('../../../lib/iocResolver')
-const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ssZZ'
 
 /**
  * The base model to share attributes with Lucid

--- a/src/Lucid/Model/PivotModel.js
+++ b/src/Lucid/Model/PivotModel.js
@@ -13,7 +13,7 @@ const moment = require('moment')
 const _ = require('lodash')
 const BaseModel = require('./Base')
 const QueryBuilder = require('../QueryBuilder')
-const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ssZZ'
 
 /**
  * Pivot model is used when a pivot relationship

--- a/test/unit/lucid-belongs-to-many.spec.js
+++ b/test/unit/lucid-belongs-to-many.spec.js
@@ -808,8 +808,8 @@ test.group('Relations | Belongs To Many', (group) => {
 
     const user = await User.query().with('posts').first()
     const json = user.toJSON()
-    assert.isTrue(moment(json.posts[0].pivot.created_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
-    assert.isTrue(moment(json.posts[0].pivot.updated_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    assert.isTrue(moment(json.posts[0].pivot.created_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
+    assert.isTrue(moment(json.posts[0].pivot.updated_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
   })
 
   test('call pivotModel getters when casting timestamps', async (assert) => {
@@ -912,8 +912,8 @@ test.group('Relations | Belongs To Many', (group) => {
     assert.lengthOf(pivotValues, 1)
     assert.equal(pivotValues[0].post_id, 1)
     assert.equal(pivotValues[0].user_id, 2)
-    assert.isTrue(moment(pivotValues[0].created_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
-    assert.isTrue(moment(pivotValues[0].updated_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    assert.isTrue(moment(pivotValues[0].created_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
+    assert.isTrue(moment(pivotValues[0].updated_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
   })
 
   test('execute setters when pivotModel in play', async (assert) => {
@@ -956,7 +956,7 @@ test.group('Relations | Belongs To Many', (group) => {
     assert.equal(pivotValues[0].post_id, 1)
     assert.equal(pivotValues[0].user_id, 2)
     assert.isTrue(moment(pivotValues[0].created_at, 'YYYY-MM-DD', true).isValid())
-    assert.isTrue(moment(pivotValues[0].updated_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    assert.isTrue(moment(pivotValues[0].updated_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
   })
 
   test('save pivot values to database', async (assert) => {

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -883,7 +883,7 @@ test.group('Model', (group) => {
     user.username = 'virk'
     await user.save()
     const keys = formatting.map((item) => item.key)
-    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(keys, ['created_at', 'updated_at'])
     assert.deepEqual(values, [true, true])
   })
@@ -904,7 +904,7 @@ test.group('Model', (group) => {
     user.username = 'nikk'
     await user.save()
     const keys = formatting.map((item) => item.key)
-    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(keys, ['updated_at'])
     assert.deepEqual(values, [true])
   })
@@ -923,7 +923,7 @@ test.group('Model', (group) => {
     await ioc.use('Database').table('users').insert({ username: 'virk' })
     await User.query().where('username', 'virk').update({ username: 'nikk' })
     const keys = formatting.map((item) => item.key)
-    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(keys, ['updated_at'])
     assert.deepEqual(values, [true])
   })
@@ -950,7 +950,7 @@ test.group('Model', (group) => {
     const timestamps = _(user.$attributes)
       .pick(['created_at', 'updated_at'])
       .map((item) => {
-        return moment(item.toString(), 'YYYY-MM-DD HH:mm:ss', true).isValid()
+        return moment(item.toString(), 'YYYY-MM-DD HH:mm:ssZZ', true).isValid()
       })
       .value()
 
@@ -978,7 +978,7 @@ test.group('Model', (group) => {
     user.username = 'virk'
     await user.save()
     const keys = formatting.map((item) => item.key)
-    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(keys, ['updated_at'])
     assert.deepEqual(values, [true])
     assert.isNull(user.created_at)
@@ -1005,7 +1005,7 @@ test.group('Model', (group) => {
     user.username = 'virk'
     await user.save()
     const keys = formatting.map((item) => item.key)
-    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    const values = formatting.map((item) => moment(item.value, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(keys, ['updated_at'])
     assert.deepEqual(values, [true])
     assert.isUndefined(user.created_at)
@@ -1054,8 +1054,8 @@ test.group('Model', (group) => {
 
     const user = await User.find(1)
     const json = user.toObject()
-    assert.isTrue(moment(json.created_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
-    assert.isTrue(moment(json.updated_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    assert.isTrue(moment(json.created_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
+    assert.isTrue(moment(json.updated_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(casting.map((field) => field.key), ['created_at', 'updated_at'])
   })
 
@@ -1139,9 +1139,9 @@ test.group('Model', (group) => {
 
     const user = await User.find(1)
     const json = user.toObject()
-    assert.isTrue(moment(json.created_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
-    assert.isTrue(moment(json.updated_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
-    assert.isTrue(moment(json.login_at, 'YYYY-MM-DD HH:mm:ss', true).isValid())
+    assert.isTrue(moment(json.created_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
+    assert.isTrue(moment(json.updated_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
+    assert.isTrue(moment(json.login_at, 'YYYY-MM-DD HH:mm:ssZZ', true).isValid())
     assert.deepEqual(casting.map((field) => field.key), ['created_at', 'updated_at', 'login_at'])
   })
 


### PR DESCRIPTION
Momentjs does use the local timezone by default. We have to call utc() to stay in UTC timezone. Otherwise we will get the timezone difference added on every save.

Same issue
https://github.com/adonisjs/adonis-lucid/issues/344