### PR TITLE
Provide seed value to Factory - possible solution for issue #884

### DIFF
--- a/src/Factory/DatabaseFactory.js
+++ b/src/Factory/DatabaseFactory.js
@@ -21,9 +21,10 @@ const { ioc } = require('../../lib/iocResolver')
  * @constructor
  */
 class DatabaseFactory {
-  constructor (tableName, dataCallback) {
+  constructor (tableName, dataCallback, options={}) {
     this.tableName = tableName
     this.dataCallback = dataCallback
+    this.options = options
     this._returningColumn = null
     this._connection = null
   }
@@ -59,7 +60,8 @@ class DatabaseFactory {
    *
    * @private
    */
-  async _makeOne (index, data) {
+  async _makeOne (index, data, seed) {
+    if (seed) chancejs.mt.init_genrand(seed+index)
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 
@@ -136,8 +138,8 @@ class DatabaseFactory {
    *
    * @return {Object}
    */
-  async make (data = {}, index = 0) {
-    return this._makeOne(index, data)
+  async make (data = {}, index = 0, seed=this.options.seed) {
+    return this._makeOne(index, data, seed)
   }
 
   /**
@@ -152,8 +154,8 @@ class DatabaseFactory {
    *
    * @return {Array}
    */
-  async makeMany (instances, data = {}) {
-    return Promise.all(_.map(_.range(instances), (index) => this.make(data, index)))
+  async makeMany (instances, data = {}, seed=this.options.seed) {
+    return Promise.all(_.map(_.range(instances), (index) => this.make(data, index, seed)))
   }
 
   /**
@@ -167,8 +169,8 @@ class DatabaseFactory {
    *
    * @return {Object}
    */
-  async create (data = {}, index = 0) {
-    const attributes = await this.make(data, index)
+  async create (data = {}, index = 0, seed=this.options.seed) {
+    const attributes = await this.make(data, index, seed)
     const query = this._getQueryBuilder().table(this.tableName)
 
     if (this._returningColumn) {
@@ -190,8 +192,8 @@ class DatabaseFactory {
    *
    * @return {Array}
    */
-  async createMany (numberOfRows, data = {}) {
-    return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index)))
+  async createMany (numberOfRows, data = {}, seed=this.options.seed) {
+    return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index, seed)))
   }
 
   /**

--- a/src/Factory/DatabaseFactory.js
+++ b/src/Factory/DatabaseFactory.js
@@ -21,7 +21,7 @@ const { ioc } = require('../../lib/iocResolver')
  * @constructor
  */
 class DatabaseFactory {
-  constructor (tableName, dataCallback, options={}) {
+  constructor (tableName, dataCallback, options = {}) {
     this.tableName = tableName
     this.dataCallback = dataCallback
     this.options = options
@@ -61,7 +61,7 @@ class DatabaseFactory {
    * @private
    */
   async _makeOne (index, data, seed) {
-    if (seed) chancejs.mt.init_genrand(seed+index)
+    if (seed) chancejs.mt.init_genrand(seed + index)
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 
@@ -138,7 +138,7 @@ class DatabaseFactory {
    *
    * @return {Object}
    */
-  async make (data = {}, index = 0, seed=this.options.seed) {
+  async make (data = {}, index = 0, seed = this.options.seed) {
     return this._makeOne(index, data, seed)
   }
 
@@ -154,7 +154,7 @@ class DatabaseFactory {
    *
    * @return {Array}
    */
-  async makeMany (instances, data = {}, seed=this.options.seed) {
+  async makeMany (instances, data = {}, seed = this.options.seed) {
     return Promise.all(_.map(_.range(instances), (index) => this.make(data, index, seed)))
   }
 
@@ -169,7 +169,7 @@ class DatabaseFactory {
    *
    * @return {Object}
    */
-  async create (data = {}, index = 0, seed=this.options.seed) {
+  async create (data = {}, index = 0, seed = this.options.seed) {
     const attributes = await this.make(data, index, seed)
     const query = this._getQueryBuilder().table(this.tableName)
 
@@ -192,7 +192,7 @@ class DatabaseFactory {
    *
    * @return {Array}
    */
-  async createMany (numberOfRows, data = {}, seed=this.options.seed) {
+  async createMany (numberOfRows, data = {}, seed = this.options.seed) {
     return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index, seed)))
   }
 

--- a/src/Factory/DatabaseFactory.js
+++ b/src/Factory/DatabaseFactory.js
@@ -10,7 +10,7 @@
 */
 
 const _ = require('lodash')
-const chancejs = require('./chance')
+const Chance = require('./chance')
 const { ioc } = require('../../lib/iocResolver')
 
 /**
@@ -61,7 +61,7 @@ class DatabaseFactory {
    * @private
    */
   async _makeOne (index, data, seed) {
-    if (seed) chancejs.mt.init_genrand(seed + index)
+    const chancejs = seed ? new Chance(seed + index) : new Chance();
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 

--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -21,7 +21,7 @@ const { ioc } = require('../../lib/iocResolver')
  * @constructor
  */
 class ModelFactory {
-  constructor (Model, dataCallback, options={}) {
+  constructor (Model, dataCallback, options = {}) {
     this.Model = Model
     this.dataCallback = dataCallback
     this.options = options
@@ -60,7 +60,7 @@ class ModelFactory {
    * @private
    */
   async _makeOne (index, data, seed) {
-    if (seed) chancejs.mt.init_genrand(seed+index)
+    if (seed) chancejs.mt.init_genrand(seed + index)
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 
@@ -92,7 +92,7 @@ class ModelFactory {
    *
    * @return {Object}
    */
-  async make (data = {}, index = 0, seed=this.options.seed) {
+  async make (data = {}, index = 0, seed = this.options.seed) {
     const attributes = await this._makeOne(index, data, seed)
     return this._newup(attributes)
   }
@@ -109,7 +109,7 @@ class ModelFactory {
    *
    * @return {Array}
    */
-  async makeMany (instances, data = {}, seed=this.options.seed) {
+  async makeMany (instances, data = {}, seed = this.options.seed) {
     return Promise.all(_.map(_.range(instances), (index) => this.make(data, index, seed)))
   }
 
@@ -124,7 +124,7 @@ class ModelFactory {
    *
    * @return {Object}
    */
-  async create (data = {}, index = 0, seed=this.options.seed) {
+  async create (data = {}, index = 0, seed = this.options.seed) {
     const modelInstance = await this.make(data, index, seed)
     await modelInstance.save()
     return modelInstance
@@ -142,7 +142,7 @@ class ModelFactory {
    *
    * @return {Array}
    */
-  async createMany (numberOfRows, data = {}, seed=this.options.seed) {
+  async createMany (numberOfRows, data = {}, seed = this.options.seed) {
     return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index, seed)))
   }
 

--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -21,9 +21,10 @@ const { ioc } = require('../../lib/iocResolver')
  * @constructor
  */
 class ModelFactory {
-  constructor (Model, dataCallback) {
+  constructor (Model, dataCallback, options={}) {
     this.Model = Model
     this.dataCallback = dataCallback
+    this.options = options
   }
 
   /**
@@ -58,7 +59,8 @@ class ModelFactory {
    *
    * @private
    */
-  async _makeOne (index, data) {
+  async _makeOne (index, data, seed) {
+    if (seed) chancejs.mt.init_genrand(seed+index)
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 
@@ -90,8 +92,8 @@ class ModelFactory {
    *
    * @return {Object}
    */
-  async make (data = {}, index = 0) {
-    const attributes = await this._makeOne(index, data)
+  async make (data = {}, index = 0, seed=this.options.seed) {
+    const attributes = await this._makeOne(index, data, seed)
     return this._newup(attributes)
   }
 
@@ -107,8 +109,8 @@ class ModelFactory {
    *
    * @return {Array}
    */
-  async makeMany (instances, data = {}) {
-    return Promise.all(_.map(_.range(instances), (index) => this.make(data, index)))
+  async makeMany (instances, data = {}, seed=this.options.seed) {
+    return Promise.all(_.map(_.range(instances), (index) => this.make(data, index, seed)))
   }
 
   /**
@@ -122,8 +124,8 @@ class ModelFactory {
    *
    * @return {Object}
    */
-  async create (data = {}, index = 0) {
-    const modelInstance = await this.make(data, index)
+  async create (data = {}, index = 0, seed=this.options.seed) {
+    const modelInstance = await this.make(data, index, seed)
     await modelInstance.save()
     return modelInstance
   }
@@ -140,8 +142,8 @@ class ModelFactory {
    *
    * @return {Array}
    */
-  async createMany (numberOfRows, data = {}) {
-    return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index)))
+  async createMany (numberOfRows, data = {}, seed=this.options.seed) {
+    return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index, seed)))
   }
 
   /**

--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -10,7 +10,7 @@
 */
 
 const _ = require('lodash')
-const chancejs = require('./chance')
+const Chance = require('./chance')
 const { ioc } = require('../../lib/iocResolver')
 
 /**
@@ -60,7 +60,7 @@ class ModelFactory {
    * @private
    */
   async _makeOne (index, data, seed) {
-    if (seed) chancejs.mt.init_genrand(seed + index)
+    const chancejs = seed ? new Chance(seed + index) : new Chance();
     const hash = await this.dataCallback(chancejs, index, data)
     const keys = _.keys(hash)
 

--- a/src/Factory/chance.js
+++ b/src/Factory/chance.js
@@ -9,26 +9,31 @@
  * file that was distributed with this source code.
 */
 
-const chance = require('chance').Chance()
+const Chance = require('chance')
 const _ = require('lodash')
 
-/**
- * Adding custom mixins
- */
-chance.mixin({
-  username: function (length) {
-    length = length || 5
-    return chance.word({length})
-  },
+class Chancejs extends Chance {
+  constructor (seed = null) {
+    seed ? super(seed) : super()
 
-  password: function (length) {
-    length = length || 20
-    const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-    return _.map(_.range(length), () => {
-      return charset.charAt(Math.floor(Math.random() * charset.length))
-    }).join('')
+    /**
+     * Adding custom mixins
+     */
+    this.mixin({
+      username: function (length) {
+        length = length || 5
+        return this.word({length})
+      },
+
+      password: function (length) {
+        length = length || 20
+        const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+        return _.map(_.range(length), () => {
+          return charset.charAt(Math.floor(Math.random() * charset.length))
+        }).join('')
+      }
+    })
   }
+}
 
-})
-
-module.exports = chance
+module.exports = Chancejs

--- a/src/Factory/index.js
+++ b/src/Factory/index.js
@@ -55,13 +55,13 @@ class Factory {
    * })
    * ```
    */
-  blueprint (name, callback) {
+  blueprint (name, callback, options) {
     if (typeof (callback) !== 'function') {
       throw GE
         .InvalidArgumentException
         .invalidParameter('Factory.blueprint expects a callback as 2nd parameter', callback)
     }
-    this._blueprints.push({ name, callback })
+    this._blueprints.push({ name, callback, options })
     return this
   }
 
@@ -90,7 +90,7 @@ class Factory {
    */
   model (name) {
     const blueprint = this.getBlueprint(name)
-    return new ModelFactory(blueprint.name, blueprint.callback)
+    return new ModelFactory(blueprint.name, blueprint.callback, blueprint.options)
   }
 
   /**
@@ -104,7 +104,7 @@ class Factory {
    */
   get (name) {
     const blueprint = this.getBlueprint(name)
-    return new DatabaseFactory(blueprint.name, blueprint.callback)
+    return new DatabaseFactory(blueprint.name, blueprint.callback, blueprint.options)
   }
 
   /**

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -62,8 +62,8 @@ test.group('Factory', (group) => {
 
   test('add a new blueprint', (assert) => {
     const fn = function () {}
-    Factory.blueprint('App/Model/User', fn)
-    assert.deepEqual(Factory._blueprints, [{ name: 'App/Model/User', callback: fn }])
+    Factory.blueprint('App/Model/User', fn, {})
+    assert.deepEqual(Factory._blueprints, [{ name: 'App/Model/User', callback: fn, options: {} }])
   })
 
   test('get model factory when accessing the blueprint', (assert) => {


### PR DESCRIPTION
Proposed solution for issue #884: https://github.com/adonisjs/adonis-framework/issues/884

This update allows a seed to be passed into a Factory blueprint for consistent seeded data.

Example of seeding a factory blueprint:
```
Factory.blueprint('App/Models/User', async (faker) => {
  return {
    username: faker.username(),
    password: await Hash.make(faker.password())
  }
}, {seed:1234})
```
Another option is to seed when generating an instance, not necessarily needed if seed is on the blueprint but this will override the blueprint seed.
```
const user = await Factory
  .model('App/Models/User')
  .create({}, 0, 1234)
```
```
const usersArray = await Factory
  .model('App/Models/User')
  .createMany(5, {}, 1234)
```

Note, the actual seed value is made up of the passed seed plus the index to handle when creating many items. 