### PR TITLE
Added trx support to findOrCreate

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -954,10 +954,19 @@ class Model extends BaseModel {
       payload = whereClause
     }
 
+    const query = this.query();
+
+     /**
+     * If trx is defined then use it for operation
+     */
+    if (trx) {
+      query.transacting(trx)
+    }
+
     /**
      * Find a row using where clause
      */
-    const row = await this.query().where(whereClause).first()
+    const row = await query.where(whereClause).first()
     if (row) {
       return row
     }

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -954,9 +954,9 @@ class Model extends BaseModel {
       payload = whereClause
     }
 
-    const query = this.query();
+    const query = this.query()
 
-     /**
+    /**
      * If trx is defined then use it for operation
      */
     if (trx) {

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -1657,6 +1657,26 @@ test.group('Model', (group) => {
     assert.equal(user.username, 'foo')
   })
 
+  test('create a new row when unable to find one using trx', async (assert) => {
+    class User extends Model {
+      static boot () {
+        super.boot()
+      }
+    }
+
+    User._bootIfNotBooted()
+
+    const count = await ioc.use('Database').table('users').count('* as total')
+    assert.equal(count[0].total, 0)
+
+    const trx = await ioc.use('Database').beginTransaction()
+    const user = await User.findOrCreate({ username: 'foo' }, { username: 'virk' }, trx)
+    await trx.commit()
+
+    assert.isTrue(user.$persisted)
+    assert.equal(user.username, 'virk')
+  })
+
   test('return existing row when found one', async (assert) => {
     class User extends Model {
     }

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -1693,6 +1693,29 @@ test.group('Model', (group) => {
     assert.equal(helpers.formatQuery(usersQuery.sql), helpers.formatQuery('select * from "users" where "username" = ? limit ?'))
   })
 
+  test('return existing row when found one using trx', async (assert) => {
+    class User extends Model {
+      static boot () {
+        super.boot()
+      }
+    }
+
+    User._bootIfNotBooted()
+
+    let usersQuery = null
+    User.onQuery((query) => (usersQuery = query))
+
+    await ioc.use('Database').table('users').insert({ username: 'foo' })
+
+    const trx = await ioc.use('Database').beginTransaction()
+    const user = await User.findOrCreate({ username: 'foo' }, { username: 'virk' }, trx)
+    await trx.commit()
+
+    assert.isTrue(user.$persisted)
+    assert.equal(user.username, 'foo')
+    assert.equal(helpers.formatQuery(usersQuery.sql), helpers.formatQuery('select * from "users" where "username" = ? limit ?'))
+  })
+
   test('pass different payload for create', async (assert) => {
     class User extends Model {
     }


### PR DESCRIPTION
Conditionally use trx when exists in findOrCreate method

## Proposed changes

Fix the stuck timeout problem when using trx with findOrCreate

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)