### PR TITLE
feat(Model.delete): add suport for transactions

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -799,16 +799,27 @@ class Model extends BaseModel {
    * @method delete
    * @async
    *
+   * @param {Object} trx
+   *
    * @return {Boolean}
    */
-  async delete () {
+  async delete (trx) {
     /**
      * Executing before hooks
      */
     await this.constructor.$hooks.before.exec('delete', this)
 
-    const affected = await this.constructor
-      .query()
+    const query = this.constructor.query()
+
+    /**
+     * If trx is defined then use it for the delete
+     * operation.
+     */
+    if (trx) {
+      query.transacting(trx)
+    }
+
+    const affected = await query
       .where(this.constructor.primaryKey, this.primaryKeyValue)
       .ignoreScopes()
       .delete()

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -817,6 +817,12 @@ class Model extends BaseModel {
      */
     if (trx) {
       query.transacting(trx)
+
+      // Override `rollback` method
+      // in order to `unfreeze` the model after the transaction
+      const rollback = trx.rollback
+      trx.rollback = () =>
+        rollback().then(() => this.unfreeze())
     }
 
     const affected = await query

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -1622,6 +1622,10 @@ test.group('Model', (group) => {
 
     const count = await ioc.use('Database').table('users').count('* as total')
     assert.deepEqual(count, [{ 'total': helpers.formatNumber(0) }])
+
+    // ensure model is still frozen after transaction commit
+    assert.equal(user.$frozen, true)
+    assert.equal(user.isDeleted, true)
   })
 
   test('delete inside a rollback transaction', async (assert) => {
@@ -1646,6 +1650,10 @@ test.group('Model', (group) => {
 
     const count = await ioc.use('Database').table('users').count('* as total')
     assert.deepEqual(count, [{ 'total': helpers.formatNumber(1) }])
+
+    // ensure model is not frozen anymore as well
+    assert.equal(user.$frozen, false)
+    assert.equal(user.isDeleted, false)
   })
 
   test('define runtime visible fields', async (assert) => {


### PR DESCRIPTION
## Proposed changes

Support `transaction` as parameter of `Model.delete(trx)`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)