### PR TITLE
Added seed option for migration run and refresh

### DIFF
--- a/commands/MigrationRefresh.js
+++ b/commands/MigrationRefresh.js
@@ -67,7 +67,7 @@ class MigrationRefresh extends BaseMigration {
     }
 
     await ace.call('migration:reset', {}, { log, force, silent })
-    await ace.call('migration:run', {}, { log, force, silent, seed })
+    await ace.call('migration:run', {}, { log, force, silent, seed, keepAlive })
   }
 }
 

--- a/commands/MigrationRefresh.js
+++ b/commands/MigrationRefresh.js
@@ -25,6 +25,7 @@ class MigrationRefresh extends BaseMigration {
     migration:refresh
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
+    { --seed: Seed the database after migration finished }
     { --log: Log SQL queries instead of executing them }
     { -a, --keep-alive: Do not close the database connection }
     `
@@ -53,11 +54,12 @@ class MigrationRefresh extends BaseMigration {
    * @param  {Boolean} options.log
    * @param  {Boolean} options.force
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.seed
    * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, silent, keepAlive }) {
+  async handle (args, { log, force, silent, seed, keepAlive }) {
     this._validateState(force)
 
     if (keepAlive) {
@@ -65,7 +67,7 @@ class MigrationRefresh extends BaseMigration {
     }
 
     await ace.call('migration:reset', {}, { log, force, silent })
-    await ace.call('migration:run', {}, { log, force, silent })
+    await ace.call('migration:run', {}, { log, force, silent, seed })
   }
 }
 

--- a/commands/MigrationRun.js
+++ b/commands/MigrationRun.js
@@ -12,6 +12,7 @@
 const BaseMigration = require('./BaseMigration')
 const _ = require('lodash')
 const prettyHrTime = require('pretty-hrtime')
+const ace = require('@adonisjs/ace')
 
 class MigrationRun extends BaseMigration {
   /**
@@ -26,6 +27,7 @@ class MigrationRun extends BaseMigration {
     migration:run
     { -f, --force: Forcefully run migrations in production }
     { -s, --silent: Silent the migrations output }
+    { --seed: Seed the database after migration finished }
     { --log: Log SQL queries instead of executing them }
     { -a, --keep-alive: Do not close the database connection }
     `
@@ -53,11 +55,12 @@ class MigrationRun extends BaseMigration {
    * @param  {Boolean} options.log
    * @param  {Boolean} options.force
    * @param  {Boolean} options.silent
+   * @param  {Boolean} options.seed
    * @param  {Boolean} options.keepAlive
    *
    * @return {void|Array}
    */
-  async handle (args, { log, force, silent, keepAlive }) {
+  async handle (args, { log, force, silent, seed, keepAlive }) {
     try {
       this._validateState(force)
 
@@ -93,6 +96,13 @@ class MigrationRun extends BaseMigration {
           _.each(queries, (query) => this.execIfNot(silent, () => console.log(`  ${query}`)))
           console.log('\n')
         })
+      }
+
+      /**
+       * If seed is passed, seed the DB after migration
+       */
+      if (seed) {
+        await ace.call('seed')
       }
 
       if (!this.viaAce) {

--- a/commands/MigrationRun.js
+++ b/commands/MigrationRun.js
@@ -102,7 +102,7 @@ class MigrationRun extends BaseMigration {
        * If seed is passed, seed the DB after migration
        */
       if (seed) {
-        await ace.call('seed')
+        await ace.call('seed', {}, { keepAlive, force })
       }
 
       if (!this.viaAce) {


### PR DESCRIPTION
## Proposed changes

Added `--seed` option to `migrate:run` and `migrate:refresh` for seeding after migration has ran.

## Types of changes

What types of changes does your code introduce?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)