### PR TITLE
Use lodash isEqual to check if a model is dirty

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -424,7 +424,7 @@ class Model extends BaseModel {
    */
   get dirty () {
     return _.pickBy(this.$attributes, (value, key) => {
-      return _.isUndefined(this.$originalAttributes[key]) || this.$originalAttributes[key] !== value
+      return _.isUndefined(this.$originalAttributes[key]) || !_.isEqual(this.$originalAttributes[key], value)
     })
   }
 


### PR DESCRIPTION
## Proposed changes

This fix uses `_.isEqual` instead of `!==` in the `dirty` getter to compare $attributes and $originalAttributes.

This allows comparaison with json objects.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)