### PR TITLE
Sync original attributes after update hook execution

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -663,7 +663,9 @@ class Model extends BaseModel {
       query.transacting(trx)
     }
 
-    if (this.isDirty) {
+    const isDirty = this.isDirty
+
+    if (isDirty) {
       /**
        * Set proper timestamps
       */
@@ -674,16 +676,20 @@ class Model extends BaseModel {
         .where(this.constructor.primaryKey, this.primaryKeyValue)
         .ignoreScopes()
         .update(this)
-      /**
-       * Sync originals to find a diff when updating for next time
-       */
-      this._syncOriginals()
     }
 
     /**
      * Executing after hooks
      */
     await this.constructor.$hooks.after.exec('update', this)
+
+    if (isDirty) {
+      /**
+       * Sync originals to find a diff when updating for next time
+       */
+      this._syncOriginals()
+    }
+
     return !!affected
   }
 


### PR DESCRIPTION
## Proposed changes

This PR allows to execute `afterUpdate` hook before `this.syncOriginals()`.

This allows to check dirty attributes in this hook. And if someone wants $originalAttributes to be synced in this hook, he can call the method manually.

I'd like to hear if it's a good idea or not because it is very specific to my project. 

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
