### PR TITLE
Pagination null should return 0 as string

### DIFF
--- a/src/Database/MonkeyPatch.js
+++ b/src/Database/MonkeyPatch.js
@@ -151,11 +151,11 @@ KnexQueryBuilder.prototype.paginate = async function (page = 1, perPage = 20) {
   })
 
   const counts = await countByQuery.count('* as total')
-  const total = _.get(counts, '0.total', '0')
+  const total = _.get(counts, '0.total', 0)
   const data = total === 0 ? [] : await this.forPage(page, perPage)
 
   return {
-    total: total,
+    total: String(total),
     perPage: perPage,
     page: page,
     lastPage: Math.ceil(total / perPage),

--- a/src/Database/MonkeyPatch.js
+++ b/src/Database/MonkeyPatch.js
@@ -151,7 +151,7 @@ KnexQueryBuilder.prototype.paginate = async function (page = 1, perPage = 20) {
   })
 
   const counts = await countByQuery.count('* as total')
-  const total = _.get(counts, '0.total', 0)
+  const total = _.get(counts, '0.total', '0')
   const data = total === 0 ? [] : await this.forPage(page, perPage)
 
   return {


### PR DESCRIPTION
## Proposed changes

Paginate method should returns a total 0 as string when result is NULL, for example with a LEFT JOIN.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)