### PR TITLE
Fix typo in JSDoc

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -90,7 +90,7 @@ class Database {
    *
    * @method on
    *
-   * @param  {Strign}   event
+   * @param  {String}   event
    * @param  {Function} callback
    *
    * @chainable


### PR DESCRIPTION
Just fix a typo in JSDoc by swap letter `g` and `n`. Not introduce any new features, no breaking changes, and fully backward compatible.