### PR TITLE
Included use of transaction in query related methods inside LucidModel

### DIFF
--- a/test/unit/lucid-relations.spec.js
+++ b/test/unit/lucid-relations.spec.js
@@ -15,7 +15,6 @@ const fs = require('fs-extra')
 const path = require('path')
 const { ioc } = require('@adonisjs/fold')
 const { Config } = require('@adonisjs/sink')
-const { TimeoutError } = require('tarn')
 
 const helpers = require('./helpers')
 const Model = require('../../src/Lucid/Model')

--- a/test/unit/lucid-relations.spec.js
+++ b/test/unit/lucid-relations.spec.js
@@ -1978,4 +1978,75 @@ test.group('Relations | HasOne', (group) => {
     assert.instanceOf(car.$relations.user, User)
     assert.equal(car.$relations.user.$attributes.id, 1)
   })
+
+  test('loadMany inside the context of a transaction', async (assert) => {
+    class Car extends Model {
+    }
+
+    class Profile extends Model {
+    }
+
+    class User extends Model {
+      car () {
+        return this.hasOne(Car)
+      }
+
+      profile () {
+        return this.hasOne(Profile)
+      }
+    }
+
+    Profile._bootIfNotBooted()
+    User._bootIfNotBooted()
+    Car._bootIfNotBooted()
+
+    let user = null
+    try {
+      await ioc.use('Database').transaction(async (trx) => {
+        await trx.table('users').insert({ username: 'virk' })
+        await trx.table('cars').insert({ name: 'E180', model: 'Mercedes', user_id: 1 })
+        await trx.table('profiles').insert({ user_id: 1, profile_name: 'virk' })
+        user = await User.query(trx).where('username', 'virk').first()
+        await user.loadMany(['car', 'profile'], trx)
+      })
+    } catch (e) {
+
+    }
+
+    assert.instanceOf(user.$relations.car, Car)
+    assert.instanceOf(user.$relations.profile, Profile)
+    assert.equal(user.$relations.car.$attributes.id, 1)
+    assert.equal(user.$relations.profile.$attributes.id, 1)
+  })
+
+  test.failing('throw a TimeoutError exception when trying to load relation of models inside the context of a transaction without using it for the load', async (assert) => {
+    class User extends Model {
+    }
+
+    class Car extends Model {
+      user () {
+        return this.belongsTo(User)
+      }
+    }
+
+    User._bootIfNotBooted()
+    Car._bootIfNotBooted()
+
+    let car = null
+    let error = null
+    try {
+      await ioc.use('Database').transaction(async (trx) => {
+        await trx.table('users').insert({ username: 'virk' })
+        await trx.table('cars').insert({ name: 'E180', model: 'Mercedes', user_id: 1 })
+        car = await Car.query(trx).select(['id', 'name', 'user_id']).where('id', 1).first()
+        await car.load('user')
+      })
+    } catch (e) {
+      error = e
+    }
+
+    assert.equal(error, null)
+    assert.instanceOf(car.$relations.user, User)
+    assert.equal(car.$relations.user.$attributes.id, 1)
+  })
 })

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -2068,4 +2068,17 @@ test.group('Model', (group) => {
 
     assert.equal(helpers.formatTime(user.updated_at), helpers.formatTime(updatedAt))
   })
+
+  test('usage of query in context of a transaction', async (assert) => {
+    class User extends Model {
+    }
+
+    User._bootIfNotBooted()
+
+    let trx = await ioc.use('Database').beginTransaction()
+    const user = await User.create({ username: 'virk' }, trx)
+    const userFromQuery = await User.query(trx).select(['username', 'id', 'created_at', 'updated_at']).where('id', 1).first()
+    await trx.commit()
+    assert.deepEqual(user.toJSON(), userFromQuery.toJSON())
+  })
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This PR aims to allow a greater use of transactions within the Lucid Model methods, because currently the use of transactions was restricted to insertions within the database which does not allow us to perform a greater amount of functionality such as deleting, loading relations and searches related to the context itself to which that transaction occurs.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

This PR also solves a issue caused by usage of load function for loading a related model in the context of a model related to a transaction.