### PR TITLE
Throw error in case we don't pass a number to createMany/makeMany

### DIFF
--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -109,7 +109,7 @@ class ModelFactory {
    * @return {Array}
    */
   async makeMany (instances, data = {}) {
-    if (typeof (instances) !== 'number'){
+    if (typeof (instances) !== 'number') {
       throw GE
         .InvalidArgumentException
         .invalidParameter('ModelFactory.makeMany() expects the number of instances as first argument', instances)
@@ -148,7 +148,7 @@ class ModelFactory {
    * @return {Array}
    */
   async createMany (numberOfRows, data = {}) {
-    if (typeof (numberOfRows) !== 'number'){
+    if (typeof (numberOfRows) !== 'number') {
       throw GE
         .InvalidArgumentException
         .invalidParameter('ModelFactory.createMany() expects the number of rows as first argument', numberOfRows)

--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
 */
 
+const GE = require('@adonisjs/generic-exceptions')
 const _ = require('lodash')
 const chancejs = require('./chance')
 const { ioc } = require('../../lib/iocResolver')
@@ -108,6 +109,12 @@ class ModelFactory {
    * @return {Array}
    */
   async makeMany (instances, data = {}) {
+    if (typeof (instances) !== 'number'){
+      throw GE
+        .InvalidArgumentException
+        .invalidParameter('ModelFactory.makeMany() expects the number of instances as first argument', instances)
+    }
+
     return Promise.all(_.map(_.range(instances), (index) => this.make(data, index)))
   }
 
@@ -141,6 +148,12 @@ class ModelFactory {
    * @return {Array}
    */
   async createMany (numberOfRows, data = {}) {
+    if (typeof (numberOfRows) !== 'number'){
+      throw GE
+        .InvalidArgumentException
+        .invalidParameter('ModelFactory.createMany() expects the number of rows as first argument', numberOfRows)
+    }
+
     return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index)))
   }
 

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -231,8 +231,11 @@ test.group('Factory', (group) => {
       return User
     })
 
-    const fn = () => Factory.model('App/Model/User').createMany({ username: 'romain' })
-    assert.throw(fn, 'E_INVALID_PARAMETER: ModelFactory.createMany() expects the number of rows as first argument')
+    try {
+      await Factory.model('App/Model/User').createMany({ username: 'romain' })
+    } catch ({ message }) {
+      assert.match(message, /E_INVALID_PARAMETER: ModelFactory.createMany() expects the number of rows as first argument/)
+    }
   })
 
   test('throw exception when factory blueprint doesn\'t have a callback', async (assert) => {
@@ -302,8 +305,11 @@ test.group('Factory', (group) => {
       }
     })
 
-    const fn = () => Factory.model('App/Model/User').makeMany({ username: 'romain' })
-    assert.throw(fn, 'E_INVALID_PARAMETER: ModelFactory.makeMany() expects the number of instances as first argument')
+    try {
+      await Factory.model('App/Model/User').makeMany({ username: 'romain' })
+    } catch ({ message }) {
+      assert.match(message, /E_INVALID_PARAMETER: ModelFactory.makeMany() expects the number of instances as first argument/)
+    }
   })
 
   test('get data object for table', async (assert) => {

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -217,6 +217,7 @@ test.group('Factory', (group) => {
   })
 
   test('throw exception when not passing a number as first argument to createMany', async (assert) => {
+    assert.plan(1)
     Factory.blueprint('App/Model/User', () => {
       return {
         username: 'virk'
@@ -292,6 +293,7 @@ test.group('Factory', (group) => {
   })
 
   test('throw exception when not passing a number as first argument to makeMany', async (assert) => {
+    assert.plan(1)
     class User extends Model {}
 
     ioc.fake('App/Model/User', () => {

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -234,7 +234,7 @@ test.group('Factory', (group) => {
     try {
       await Factory.model('App/Model/User').createMany({ username: 'romain' })
     } catch ({ message }) {
-      assert.match(message, /E_INVALID_PARAMETER: ModelFactory.createMany() expects the number of rows as first argument/)
+      assert.match(message, /^E_INVALID_PARAMETER: ModelFactory.createMany() expects the number of rows as first argument/)
     }
   })
 
@@ -308,7 +308,7 @@ test.group('Factory', (group) => {
     try {
       await Factory.model('App/Model/User').makeMany({ username: 'romain' })
     } catch ({ message }) {
-      assert.match(message, /E_INVALID_PARAMETER: ModelFactory.makeMany() expects the number of instances as first argument/)
+      assert.match(message, /^E_INVALID_PARAMETER: ModelFactory.makeMany() expects the number of instances as first argument/)
     }
   })
 

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -216,6 +216,25 @@ test.group('Factory', (group) => {
     assert.isTrue(users[1].$persisted)
   })
 
+  test('throw exception when not passing a number as first argument to createMany', async (assert) => {
+    Factory.blueprint('App/Model/User', () => {
+      return {
+        username: 'virk'
+      }
+    })
+
+    class User extends Model {
+    }
+
+    ioc.fake('App/Model/User', () => {
+      User._bootIfNotBooted()
+      return User
+    })
+
+    const fn = () => Factory.model('App/Model/User').createMany({ username: 'romain' })
+    assert.throw(fn, 'E_INVALID_PARAMETER: ModelFactory.createMany() expects the number of rows as first argument')
+  })
+
   test('throw exception when factory blueprint doesn\'t have a callback', async (assert) => {
     const fn = () => Factory.blueprint('App/Model/User')
     assert.throw(fn, 'E_INVALID_PARAMETER: Factory.blueprint expects a callback as 2nd parameter')
@@ -267,6 +286,24 @@ test.group('Factory', (group) => {
     })
     await Factory.model('App/Model/User').makeMany(2, { username: 'virk' })
     assert.deepEqual(stack, [{ username: 'virk' }, { username: 'virk' }])
+  })
+
+  test('throw exception when not passing a number as first argument to makeMany', async (assert) => {
+    class User extends Model {}
+
+    ioc.fake('App/Model/User', () => {
+      User._bootIfNotBooted()
+      return User
+    })
+
+    Factory.blueprint('App/Model/User', () => {
+      return {
+        username: 'virk'
+      }
+    })
+
+    const fn = () => Factory.model('App/Model/User').makeMany({ username: 'romain' })
+    assert.throw(fn, 'E_INVALID_PARAMETER: ModelFactory.makeMany() expects the number of instances as first argument')
   })
 
   test('get data object for table', async (assert) => {

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -1264,7 +1264,7 @@ test.group('Model', (group) => {
     assert.deepEqual(stack, ['virk', 'nikk'])
   })
 
-  test('throw an exception when createMany doesn\'t recieves an array', async (assert) => {
+  test('throw an exception when createMany doesn\'t receive an array', async (assert) => {
     assert.plan(1)
     class User extends Model {
     }


### PR DESCRIPTION
## Proposed changes

I kept passing my objects as the first arguments to the `ModelFactory` and it would silently not work. I'm now throwing error messages by type checking if the first arg is a number.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
I couldn't read the contributing.md file because it results in a dead link. I added tests and tried running them locally but couldn't run them. I'm hoping the CI will pass.

Anyone knows how I could run the tests locally? I'm on windows and just cloned the repo, ran `yarn` and `yarn test`.
```
> DB=sqlite node japaFile.js

'DB' is not recognized as an internal or external command,
operable program or batch file.
```
- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
