### PR TITLE
chore: Add a function that enables you to use traits in standalone mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,15 @@ class Ioc {
 
 class Resolver {
   forDir () {
+    return {
+      resolveFunc (binding) {
+        return {
+          instance: null,
+          isClosure: true,
+          method: binding
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Currently it is not possible to use traits in 'standalone' mode, because to add they need a function
that '@adonisjs/fold' provides. This code adds a simulation of 'resolveFunc' and enables the use
of 'traits', so it improves the use of Lucid in 'standalone'.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
