### PR TITLE
fix(proxyHandler): Mutators handled in model

### DIFF
--- a/src/Lucid/Model/proxyHandler.js
+++ b/src/Lucid/Model/proxyHandler.js
@@ -11,6 +11,7 @@
 
 const CE = require('../../Exceptions')
 const proxyGet = require('../../../lib/proxyGet')
+const _ = require('lodash')
 
 const proxyHandler = exports = module.exports = {}
 
@@ -48,5 +49,17 @@ proxyHandler.set = function (target, name, value) {
 proxyHandler.get = proxyGet('$attributes', false, function (target, name) {
   if (typeof (target.$sideLoaded[name]) !== 'undefined') {
     return target.$sideLoaded[name]
+  } else if (typeof (target.constructor.computed) === 'object' && Array.isArray(target.constructor.computed) && target.constructor.computed.indexOf(name) > -1) {
+    /**
+   * Check if name exists in computed properties
+   * if it does then convert it to camelCase & call the getName($attributes) function
+   */
+    return target[_.camelCase('get_' + name)](target.$attributes)
+  } else if (typeof (target.$attributes[name]) !== 'undefined' && typeof (target[_.camelCase('get_' + name)]) === 'function') {
+    /**
+     * Check if name exists in $attribute and function getName() exists
+     * If it does then convert it to camelCase & call the getName(attributeValue) function
+     */
+    return target[_.camelCase('get_' + name)](target.$attributes[name])
   }
 })


### PR DESCRIPTION
## Proposed changes
Mutators do not work in lucid models without converting them to objects first.
Fixes #490 
## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

I think mutators should work without converting model instance to object which is why I created this pull request.
