### PR TITLE
create records using ModelFactory's "createMany" sequentially

### DIFF
--- a/src/Factory/ModelFactory.js
+++ b/src/Factory/ModelFactory.js
@@ -141,7 +141,14 @@ class ModelFactory {
    * @return {Array}
    */
   async createMany (numberOfRows, data = {}) {
-    return Promise.all(_.map(_.range(numberOfRows), (index) => this.create(data, index)))
+    const rows = []
+
+    for (let index of _.range(numberOfRows)) {
+      const row = await this.create(data, index)
+      rows.push(row)
+    }
+
+    return rows
   }
 
   /**

--- a/test/unit/factory.spec.js
+++ b/test/unit/factory.spec.js
@@ -216,6 +216,25 @@ test.group('Factory', (group) => {
     assert.isTrue(users[1].$persisted)
   })
 
+  test('create many model instances sequentially', async (assert) => {
+    Factory.blueprint('App/Model/User', () => {
+      return {
+        username: 'virk'
+      }
+    })
+
+    class User extends Model {
+    }
+
+    ioc.fake('App/Model/User', () => {
+      User._bootIfNotBooted()
+      return User
+    })
+
+    const users = await Factory.model('App/Model/User').createMany(2)
+    assert.deepEqual(users.map(user => user.id), [1, 2])
+  })
+
   test('throw exception when factory blueprint doesn\'t have a callback', async (assert) => {
     const fn = () => Factory.blueprint('App/Model/User')
     assert.throw(fn, 'E_INVALID_PARAMETER: Factory.blueprint expects a callback as 2nd parameter')


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Adresses issue https://github.com/adonisjs/adonis-lucid/issues/489 in which "createMany" on a model factory creates records with autoincrement in random order. The content of the method is now identical with the way it is done in the `DatabaseFactory`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Not sure if the `Promise.all` was there for performance reasons. Alternatively I can sort the array like I mentioned in the issue originally.